### PR TITLE
Updated DIB_HPC_MPI: use openmpi3 instead of openmpi to match new OpenHPC names

### DIFF
--- a/dib/hpc/elements/hpc-dev-env/environment.d/91-hpc-dev-env
+++ b/dib/hpc/elements/hpc-dev-env/environment.d/91-hpc-dev-env
@@ -1,4 +1,4 @@
-# Base can be ohpc (OpenHPC) or orch (HPC Orchestrator) 
+# Base can be ohpc (OpenHPC) or orch (HPC Orchestrator)
 # Defauilt is ohpc
 export DIB_HPC_BASE=${DIB_HPC_BASE:-ohpc}
 # Are we building image for HPC sms node or compute node. Default is compute node image
@@ -8,7 +8,7 @@ export DIB_HPC_IMAGE_TYPE="${DIB_HPC_IMAGE_TYPE:-compute}"
 export DIB_HPC_COMPILER="${DIB_HPC_COMPILER:-gnu}"
 
 # MPI Stack to be installed, by default openmpi & mvapich2 is enabled
-export DIB_HPC_MPI="${DIB_HPC_MPI:-openmpi mvapich2}"
+export DIB_HPC_MPI="${DIB_HPC_MPI:-openmpi3 mvapich2}"
 
 # Performance tools
 export DIB_HPC_PERF_TOOLS="${DIB_HPC_PERF_TOOLS:-perf-tools}"


### PR DESCRIPTION
openmpi package is now called openmpi3.